### PR TITLE
docs(slides): 공식 문서·참고 자료 슬라이드 추가 (#25 후속)

### DIFF
--- a/slides/slides.md
+++ b/slides/slides.md
@@ -1179,17 +1179,67 @@ table { font-size: 0.78em; }
 </style>
 
 ---
+
+# 공식 문서·참고 자료 — Claude를 더 알고 싶다면
+
+<div grid="~ cols-3 gap-6" class="mt-6">
+
+<div>
+
+**시작하기**
+
+- [모델 안내](https://docs.claude.com/ko/docs/about-claude/models/overview)
+- [Cowork 시작](https://support.claude.com/ko/articles/13345190)
+- [Claude Code](https://docs.claude.com/ko/docs/claude-code/overview)
+- [Anthropic Learn](https://www.anthropic.com/learn) *(영문)*
+
+</div>
+
+<div>
+
+**자산화·확장**
+
+- [Projects](https://support.claude.com/ko/articles/9517075)
+- [스킬](https://support.claude.com/ko/articles/12512176)
+- [MCP](https://docs.claude.com/ko/docs/agents-and-tools/mcp) *(개발자용)*
+
+</div>
+
+<div>
+
+**운영·지원**
+
+- [요금제](https://www.anthropic.com/pricing) *(영문)*
+- [Support 홈](https://support.claude.com/ko/)
+- [Status](https://status.claude.com/)
+
+</div>
+
+</div>
+
+<div class="text-sm opacity-70 mt-8 text-center">
+한국어 페이지 우선 · 자세한 안내는 <code>docs/intro.md#official-references</code>
+</div>
+
+<style>
+a { font-size: 0.92em; }
+ul { line-height: 1.7; }
+</style>
+
+<!--
+docs/intro.md의 「공식 문서·참고 자료」 섹션 슬라이드 동기화.
+3그룹·9링크를 3컬럼으로 압축. 라벨은 docs보다 짧게(예: 「Projects(프로젝트)란 무엇입니까」 → 「Projects」), 한 줄 설명은 생략하고 docs로 위임.
+한국어 페이지가 부재한 항목은 *(영문)* 또는 *(개발자용)* 한 단어 라벨로 시각 구분.
+-->
+
+
+---
 layout: end
 ---
 
 # 감사합니다
 
-<div class="mt-12 text-base opacity-70">
-더 알아보기 → docs/intro.md (Claude 공식 자료·자세한 안내)
-</div>
-
 <!--
 Q&A 시간 안내. 질문이 있으면 끝나고 강사에게 직접 또는 사후 채널로 받겠다고 안내.
-공식 문서·참고 자료 모음은 docs/intro.md#official-references로 위임 — 슬라이드는 핵심 메시지에 집중.
 -->
 


### PR DESCRIPTION
## 이슈 목록
- #25 - 도입부 보완 (Claude 모델 설명 추가 등) — PR #26 머지 후 후속 보강

---

### Issue: #25 - 도입부 보완 (후속)

#### 1. 비즈니스 관점

* **목적 및 요약:** PR #26에서 docs에는 「공식 문서·참고 자료」 섹션을 신설했으나 슬라이드에는 인지 부하 우려로 docs 위임 1줄만 두었었다. 발표 중에도 청중이 한 자리에서 짚어볼 수 있게 슬라이드에도 동일 그룹·링크를 압축해 신설한다.

* **주요 변경 사항:**
  - 「감사합니다」 직전에 **「공식 문서·참고 자료 — Claude를 더 알고 싶다면」** 슬라이드 신설
  - 3컬럼 레이아웃(시작하기 / 자산화·확장 / 운영·지원), docs의 9링크를 라벨만 짧게 압축(설명은 docs 위임)
  - 한국어 페이지 부재 항목은 *(영문)*·*(개발자용)* 한 단어 라벨로 시각 구분
  - 「감사합니다」의 「더 알아보기 → docs/intro.md」 1줄은 신설 슬라이드와 중복되어 제거

* **참고사항:** 슬라이드 톤·자체 자산 최소화 원칙(ADR-0004) 유지 — 새 자산 없이 Slidev `grid` 유틸리티만 사용. 청중에게 9링크가 인지 부하가 될 수 있어 라벨은 짧게, 한 줄 설명은 docs로 위임.

#### 2. 테크 관점

* **구현 요약:** `slides/slides.md` 1파일 단일 변경. `<div grid="~ cols-3 gap-6">` 슬라이드 레이아웃에 3그룹의 마크다운 링크 리스트를 배치. `<style>` 블록으로 링크 폰트 크기·줄 간격만 조정.

* **변경 구조 (콘텐츠 PR — 호출 흐름 없음):**
  ```
  - slides/slides.md 도입부 끝 ~ 마지막
    ├── 「정리 — 트랙별 적용」                    # 변경 없음 (보안 섹션 마지막)
    ├── (신설) 「공식 문서·참고 자료 — Claude를 더 알고 싶다면」
    │   ├── 시작하기                            # 모델 안내·Cowork 시작·Code·Anthropic Learn (영문)
    │   ├── 자산화·확장                          # Projects·스킬·MCP (개발자용)
    │   └── 운영·지원                            # 요금제 (영문)·Support 홈·Status
    └── 「감사합니다」                            # 중복 「더 알아보기」 1줄 제거
  ```

* **검증:**
  - `npm --prefix slides run build` (Slidev) 경고/오류 없이 통과
  - `npx slidev` 로컬 서버에서 신설 슬라이드 위치·3컬럼 레이아웃·링크 표시 사용자 확인 완료

* **참고사항:**
  - ADR: `.ai/50_adr/active/adr-0002-publishing-structure-docs-ssot-slides-derivative.md` (docs SSoT → slides 단방향 파생 — 본 PR도 docs의 신설 섹션을 슬라이드로 후행 동기화), `.ai/50_adr/active/adr-0004-slides-theme-the-unnamed.md` (슬라이드 톤·자체 자산 최소화)
  - 선행 PR: #26 (머지 완료) — docs/intro.md `#official-references` 섹션이 본 슬라이드의 위임 대상